### PR TITLE
Fix GitHub Pages workflow: remove Node build and upload repo root

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,19 +20,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - name: Install dependencies
-        run: npm ci
-      - name: Build
-        run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: .
 
   deploy:
     needs: build


### PR DESCRIPTION
### Motivation
- The Pages workflow was failing due to missing Node lockfiles and build artifacts, so the CI should not attempt `npm ci`/`npm run build` for this static repository.

### Description
- Removed the Node setup and `npm` build steps and changed the Pages artifact `path` from `dist` to `.` in ` .github/workflows/deploy.yml` so the repository root is uploaded as the Pages artifact.

### Testing
- No automated tests were run because this change only updates the GitHub Actions workflow and does not modify runtime code or tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a455359048332b1ca637b9498909f)